### PR TITLE
Fix bad line wrapping in the middle of a link

### DIFF
--- a/src/jade/public/index.jade
+++ b/src/jade/public/index.jade
@@ -235,8 +235,8 @@ block content
 
                     p.animate-build(data-animation="fade-in" data-build="2")
                         | Guake was originally written by Gabriel Falcão in 2007, and has since become
-                        | a vibrant open source project with <a href="https://github.com/Guake/guake/g
-			| raphs/contributors">many contributors</a>.
+                        | a vibrant open source project with 
+                        | <a href="https://github.com/Guake/guake/graphs/contributors">many contributors</a>.
 
         .page-scroll
             #sources-hook


### PR DESCRIPTION
This fixes a link target that was unintentionally line wrapped mid attribute, instead of in between words. :wink:

This follows on from https://github.com/Guake/guake/issues/1703.

Note that I created this PR "blind" (eg without testing).  So having someone look over it first would be a really good idea. :grin: 