### PR TITLE
Fix build breakage caused by #6 rush-merging.

### DIFF
--- a/src/jade/includes/header.jade
+++ b/src/jade/includes/header.jade
@@ -22,5 +22,5 @@ nav.navbar.navbar-custom.navbar-fixed-top(role='navigation')
                 //-     a(href='#screenshots') Screenshots
                 li.page-scroll
                     a(href='#sources') Source code
-		li.page-scroll
-		    a(href='#about') About
+                li.page-scroll
+                    a(href='#about') About

--- a/src/jade/public/index.jade
+++ b/src/jade/public/index.jade
@@ -235,8 +235,9 @@ block content
 
                     p.animate-build(data-animation="fade-in" data-build="2")
                         | Guake was originally written by Gabriel Falcão in 2007, and has since become
-                        | a vibrant open source project with <a href="https://github.com/Guake/guake/g
-			| raphs/contributors">many contributors</a>.
+                        | a vibrant open source project with
+                        | a(href='https://github.com/Guake/guake/graphs/contributors') many contributors
+                        | .
 
         .page-scroll
             #sources-hook


### PR DESCRIPTION
This fixes build, broken via rush-merging #6 which was made with no respect to `.editorconfig`.

Jade isn't happy about that:

```
ulidtko@pasocon ~/s/guake-website (fix-line-wrapping)> jade src/jade/public/index.jade

/usr/local/lib/node_modules/jade/lib/runtime.js:240
  throw err;
  ^

Error: src/jade/includes/header.jade:25
    23|                 li.page-scroll
    24|                     a(href='#sources') Source code
  > 25| 		li.page-scroll
    26| 		    a(href='#about') About
    27| 

Invalid indentation, you can use tabs or spaces but not both
```

Also supersedes #9 by using native Jade syntax (`a(href='...')` instead of raw html). @justinclift is credited as the original patch author (and me as only the committer).