### PR TITLE
Fix link

### DIFF
--- a/src/jade/public/index.jade
+++ b/src/jade/public/index.jade
@@ -236,7 +236,7 @@ block content
                     p.animate-build(data-animation="fade-in" data-build="2")
                         | Guake was originally written by Gabriel Falcão in 2007, and has since become
                         | a vibrant open source project with
-                        | a(href='https://github.com/Guake/guake/graphs/contributors') many contributors
+                        | <a href="https://github.com/Guake/guake/graphs/contributors">many contributors</a>
                         | .
 
         .page-scroll


### PR DESCRIPTION
On website now link to contributors graps looks like this:
`<a href="https://github.com/Guake/guake/g
              </p>
            </div>
          </div>raphs/contributors">`